### PR TITLE
feat(live): add HeartbeatInterval config option

### DIFF
--- a/live/gateway.go
+++ b/live/gateway.go
@@ -94,12 +94,13 @@ func NewAuthenticationResponseMsgFromBytes(b []byte) *AuthenticationResponseMsg 
 // AuthenticationRequestMsg is an authentication request is sent to the gateway after a challenge response is received.
 // This is required to authenticate a user.
 type AuthenticationRequestMsg struct {
-	Auth     string       // key: auth
-	Dataset  string       // key: dataset
-	Encoding dbn.Encoding // key: encoding
-	Details  string       // key: details
-	TsOut    bool         // key: ts_out
-	Client   string       // key: client
+	Auth              string        // key: auth
+	Dataset           string        // key: dataset
+	Encoding          dbn.Encoding  // key: encoding
+	Details           string        // key: details
+	TsOut             bool          // key: ts_out
+	Client            string        // key: client
+	HeartbeatInterval time.Duration // key: heartbeat_interval (in seconds); 0 means use server default
 }
 
 // NewAuthenticationRequestMsg parses a control message and returns a AuthenticationRequestMsg
@@ -117,8 +118,14 @@ func (m *AuthenticationRequestMsg) Encode() []byte {
 	if m.TsOut {
 		tsOutStr = "1"
 	}
-	return fmt.Appendf(nil, "auth=%s|dataset=%s|encoding=%s|ts_out=%s|client=%s\n",
+	b := fmt.Appendf(nil, "auth=%s|dataset=%s|encoding=%s|ts_out=%s|client=%s",
 		m.Auth, m.Dataset, m.Encoding.String(), tsOutStr, m.Client)
+	if m.HeartbeatInterval > 0 {
+		secs := int(m.HeartbeatInterval / time.Second)
+		b = fmt.Appendf(b, "|heartbeat_interval_s=%d", secs)
+	}
+	b = append(b, '\n')
+	return b
 }
 
 // A subscription request is sent to the gateway upon request from the client.

--- a/live/live.go
+++ b/live/live.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/NimbleMarkets/dbn-go"
 )
@@ -70,6 +71,7 @@ type LiveConfig struct {
 	Client               string
 	Encoding             dbn.Encoding // nil mean Encoding_Dbn
 	SendTsOut            bool
+	HeartbeatInterval    time.Duration // Heartbeat interval; 0 means use server default
 	VersionUpgradePolicy dbn.VersionUpgradePolicy
 	Verbose              bool
 }
@@ -301,11 +303,12 @@ func (c *LiveClient) Authenticate(apiKey string) (string, error) {
 
 	// Write out the auth request
 	request := AuthenticationRequestMsg{
-		Auth:     auth,
-		Dataset:  c.config.Dataset,
-		Encoding: c.config.Encoding,
-		TsOut:    c.config.SendTsOut,
-		Client:   c.config.Client,
+		Auth:              auth,
+		Dataset:           c.config.Dataset,
+		Encoding:          c.config.Encoding,
+		TsOut:             c.config.SendTsOut,
+		Client:            c.config.Client,
+		HeartbeatInterval: c.config.HeartbeatInterval,
 	}
 	requestBytes := request.Encode()
 	if n, err := c.conn.Write(requestBytes); err != nil {


### PR DESCRIPTION
## Summary
- Add `HeartbeatInterval` (`time.Duration`) to `LiveConfig` to configure the gateway heartbeat interval
- Add `HeartbeatInterval` to `AuthenticationRequestMsg`, encoded as `heartbeat_interval_s=<seconds>` in the wire protocol
- When unset (zero value), the parameter is omitted and the gateway uses its default interval

## Motivation
The Databento Rust and Python clients support configuring `heartbeat_interval_s` in the authentication request. This brings the Go library to feature parity.

## Test plan
- Verified encoding output matches the Python client's wire format
- Tested against live gateway (`EQUS.MINI`) — heartbeats arrive at the configured interval
- Zero value correctly omits the parameter (server default behavior preserved)

## Note
During testing, I noticed that `SystemMsg.Fill_Raw()` expects v2 size (320 bytes) but the live gateway sends v1-sized SystemMsg records (80 bytes without ts_out, 88 with). This causes `Fill_Raw` to fail when decoding heartbeat records from the live gateway. This is a pre-existing issue unrelated to this PR.